### PR TITLE
Look ups with extensions go directly to files

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -19,6 +19,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
+type StorageClient interface {
+	UploadFile(file multipart.File, fileHeader multipart.FileHeader) (string, error)
+	LookupFile(prefix string) (StoredFile, error)
+}
+
 type AWSClient struct {
 	Bucket   string
 	CDN      string

--- a/main.go
+++ b/main.go
@@ -42,7 +42,9 @@ func main() {
 		os.Exit(1)
 	}
 	awsClient = *client
-	web = *NewWebServer(user, pass, port, plausible)
+	web = *NewWebServer(user, pass, port, plausible, &awsClient)
+
+	web.Start()
 }
 
 func LookupEnvDefault(envKey, defaultValue string) string {

--- a/web_test.go
+++ b/web_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type mockStorage struct {
+	StorageClient
+}
+
+func (c *mockStorage) LookupFile(prefix string) (StoredFile, error) {
+	return StoredFile{
+		OriginalName: "file.txt",
+		Url:          "http://cdn.example.com/file.txt",
+		Image:        false,
+	}, nil
+}
+
+func TestExtensionRedirect(t *testing.T) {
+	mockClient := &mockStorage{}
+	server := NewWebServer("", "", "", "", mockClient)
+
+	request := httptest.NewRequest(http.MethodGet, "/ACAB1.txt", nil)
+	responseRecorder := httptest.NewRecorder()
+	server.Router.ServeHTTP(responseRecorder, request)
+	response := responseRecorder.Result()
+
+	if response.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf(
+			`Expected redirect, but instead got %s`,
+			response.Status,
+		)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/ACAB1.gif", nil)
+	responseRecorder = httptest.NewRecorder()
+	server.Router.ServeHTTP(responseRecorder, request)
+	response = responseRecorder.Result()
+
+	if response.StatusCode == http.StatusMovedPermanently {
+		t.Fatalf(
+			`Did not expect redirect, got it anyway`,
+		)
+	}
+}


### PR DESCRIPTION
Especially for unfurls in IRCCloud, having direct links to stuff is handy! I wanted to just allow suffixing the original extension to work here. Additionally, I added a `StorageClient` interface and removed some global variable use in `web.go` to make testing a bit easier.

---
Closes https://github.com/skalnik/file-cloud/issues/12