### PR TITLE
Add Dockerfile & Use it for deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+COPY static/ static/
+COPY templates templates/
+
+RUN go build -o /file-cloud
+
+EXPOSE 8080
+
+CMD ["/file-cloud"]

--- a/fly.toml
+++ b/fly.toml
@@ -9,10 +9,6 @@ kill_timeout = 5
 [env]
   PORT = "8080"
 
-[build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/go"]
-
 [[services]]
   protocol = "tcp"
   internal_port = 8080


### PR DESCRIPTION
The build packs have been doing weird things (see https://github.com/skalnik/file-cloud/actions/runs/16160017943/job/45609835437?pr=33), so this PR goes ahead and adds a simple Dockerfile and uses it for Fly.io deployments.