### PR TITLE
Fix busted 404 page

### DIFF
--- a/web.go
+++ b/web.go
@@ -143,6 +143,7 @@ func (webServer *WebServer) LookupHandler(writer http.ResponseWriter, request *h
 	file, err := webServer.storage.LookupFile(key)
 	if err != nil {
 		webServer.ServeError(writer, err)
+		return
 	}
 
 	webServer.ServeTemplate(writer, "file", *file)


### PR DESCRIPTION
I randomly hit a missing file and instead of the 404 page, it was busted. I noticed the logs showed a panic, and turns out that's happening due to a missing `return`. Added that along with a test for it.